### PR TITLE
alert when severity is unknown

### DIFF
--- a/pkg/collectors/policyreport.go
+++ b/pkg/collectors/policyreport.go
@@ -117,9 +117,9 @@ func getReports(clusterID string, pr *v1alpha2.PolicyReport) [][]string {
 		case "1":
 			severity = "low"
 		default:
-			severity = ""
+			severity = "unknown"
 		}
-		if reportResult.Policy != "" && category != "" && result != "" && severity != "" {
+		if reportResult.Policy != "" && category != "" && result != "" {
 			policy = reportResult.Policy
 			metric = append(metric, clusterID, category, policy, result, severity)
 			metrics = append(metrics, metric)


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Currently if the `total_risk` field is set to a value other than 1, 2, 3, or 4 (which happens when the severity field is incorrectly specified in a GRC policy) the metrics client doesn't generate metrics for those violations. This causes issues like https://github.com/open-cluster-management/backlog/issues/16203 where the severity is set to "med" in the policy instead of "medium." This PR enables metrics for those policies with the severity field set to "unknown" to keep consistency with metrics for other policies / insights violations